### PR TITLE
Add Tkinter GUI for eBay watch listings and extend API filters

### DIFF
--- a/src/ebay_api.py
+++ b/src/ebay_api.py
@@ -1,24 +1,46 @@
 """Interface to the eBay Finding API."""
 
 import requests
-from typing import List, Dict
+from typing import Dict, List, Optional
 
 from config import EBAY_APP_ID
 
 FINDING_API_ENDPOINT = "https://svcs.ebay.com/services/search/FindingService/v1"
 
 
-def fetch_listings(brand: str, max_price: float, entries: int = 20) -> List[Dict]:
-    """Fetch watch listings from eBay filtered by brand and maximum price.
+def fetch_listings(
+    brand: str,
+    max_price: Optional[float] = None,
+    entries: int = 20,
+    model_keywords: Optional[str] = None,
+    min_price: Optional[float] = None,
+    condition: Optional[str] = None,
+    listing_type: Optional[str] = None,
+    max_time_left: Optional[int] = None,
+    exclude_keywords: Optional[str] = None,
+) -> List[Dict]:
+    """Fetch watch listings from eBay filtered by various parameters.
 
     Parameters
     ----------
     brand : str
         Brand keyword to search for. Only a single brand is supported.
-    max_price : float
+    max_price : float, optional
         Maximum listing price in USD.
     entries : int, optional
         Number of results to fetch, by default 20.
+    model_keywords : str, optional
+        Additional model keywords.
+    min_price : float, optional
+        Minimum listing price in USD.
+    condition : {"New", "Used"}, optional
+        Filter by condition.
+    listing_type : {"Auction", "BIN"}, optional
+        Filter by listing type (BIN stands for Buy It Now).
+    max_time_left : int, optional
+        Maximum time left in hours.
+    exclude_keywords : str, optional
+        Comma-separated keywords to exclude from search.
 
     Returns
     -------
@@ -28,21 +50,66 @@ def fetch_listings(brand: str, max_price: float, entries: int = 20) -> List[Dict
     if not EBAY_APP_ID:
         raise ValueError("EBAY_APP_ID environment variable is not set")
 
+    keywords = f"{brand}"
+    if model_keywords:
+        keywords += f" {model_keywords}"
+    keywords += " watch"
+
+    if exclude_keywords:
+        for word in exclude_keywords.split(","):
+            w = word.strip()
+            if w:
+                keywords += f" -{w}"
+
     params = {
         "OPERATION-NAME": "findItemsAdvanced",
         "SERVICE-VERSION": "1.0.0",
         "SECURITY-APPNAME": EBAY_APP_ID,
         "RESPONSE-DATA-FORMAT": "JSON",
         "REST-PAYLOAD": "",
-        "keywords": f"{brand} watch",
+        "keywords": keywords,
         "paginationInput.entriesPerPage": entries,
-        "itemFilter(0).name": "MaxPrice",
-        "itemFilter(0).value": max_price,
-        "itemFilter(0).paramName": "Currency",
-        "itemFilter(0).paramValue": "USD",
         "aspectFilter(0).aspectName": "Brand",
         "aspectFilter(0).aspectValueName": brand,
     }
+
+    item_filters: List[Dict[str, str]] = []
+    if max_price is not None:
+        item_filters.append(
+            {
+                "name": "MaxPrice",
+                "value": str(max_price),
+                "paramName": "Currency",
+                "paramValue": "USD",
+            }
+        )
+    if min_price is not None:
+        item_filters.append(
+            {
+                "name": "MinPrice",
+                "value": str(min_price),
+                "paramName": "Currency",
+                "paramValue": "USD",
+            }
+        )
+    if condition in {"New", "Used"}:
+        condition_code = {"New": "1000", "Used": "3000"}[condition]
+        item_filters.append({"name": "Condition", "value": condition_code})
+    if listing_type in {"Auction", "BIN"}:
+        lt_value = "Auction" if listing_type == "Auction" else "FixedPrice"
+        item_filters.append({"name": "ListingType", "value": lt_value})
+    if max_time_left:
+        item_filters.append(
+            {"name": "MaxTimeLeft", "value": f"PT{int(max_time_left)}H"}
+        )
+
+    for idx, fil in enumerate(item_filters):
+        params[f"itemFilter({idx}).name"] = fil["name"]
+        params[f"itemFilter({idx}).value"] = fil["value"]
+        if "paramName" in fil:
+            params[f"itemFilter({idx}).paramName"] = fil["paramName"]
+        if "paramValue" in fil:
+            params[f"itemFilter({idx}).paramValue"] = fil["paramValue"]
 
     response = requests.get(FINDING_API_ENDPOINT, params=params, timeout=10)
     response.raise_for_status()

--- a/src/gui.py
+++ b/src/gui.py
@@ -1,0 +1,125 @@
+import tkinter as tk
+from tkinter import messagebox
+import pandas as pd
+
+from ebay_api import fetch_listings
+from excel_exporter import export_to_excel
+
+
+def fetch_from_gui():
+    brand = brand_entry.get().strip()
+    model = model_entry.get().strip()
+    min_price = min_price_entry.get().strip()
+    max_price = max_price_entry.get().strip()
+    condition = condition_var.get()
+    listing_type = listing_type_var.get()
+    time_left = time_left_var.get()
+    exclude = exclude_entry.get().strip()
+    entries = result_var.get()
+
+    kwargs = {"entries": entries}
+    if model:
+        kwargs["model_keywords"] = model
+    if min_price:
+        try:
+            kwargs["min_price"] = float(min_price)
+        except ValueError:
+            messagebox.showerror("Error", "Invalid min price")
+            return
+    if max_price:
+        try:
+            kwargs["max_price"] = float(max_price)
+        except ValueError:
+            messagebox.showerror("Error", "Invalid max price")
+            return
+    if condition != "Any":
+        kwargs["condition"] = condition
+    if listing_type != "Both":
+        kwargs["listing_type"] = listing_type
+    if time_left != "Any":
+        kwargs["max_time_left"] = int(time_left.replace("h", ""))
+    if exclude:
+        kwargs["exclude_keywords"] = exclude
+
+    try:
+        listings = fetch_listings(brand, **kwargs)
+    except Exception as exc:
+        messagebox.showerror("Error", str(exc))
+        return
+
+    df = pd.DataFrame(listings)
+    if not df.empty:
+        df.rename(
+            columns={
+                "title": "Title",
+                "price": "Price",
+                "url": "URL",
+                "end_time": "End Time",
+            },
+            inplace=True,
+        )
+    else:
+        df = pd.DataFrame(columns=["Title", "Price", "URL", "End Time"])
+
+    export_to_excel(df)
+    messagebox.showinfo("Success", f"Exported {len(df)} listings to listings.xlsx")
+
+
+root = tk.Tk()
+root.title("Watch Listings Fetcher")
+
+# Brand
+tk.Label(root, text="Brand").grid(row=0, column=0, sticky="w")
+brand_entry = tk.Entry(root)
+brand_entry.grid(row=0, column=1)
+
+# Model keywords
+tk.Label(root, text="Model").grid(row=1, column=0, sticky="w")
+model_entry = tk.Entry(root)
+model_entry.grid(row=1, column=1)
+
+# Min price
+tk.Label(root, text="Min Price").grid(row=2, column=0, sticky="w")
+min_price_entry = tk.Entry(root)
+min_price_entry.grid(row=2, column=1)
+
+# Max price
+tk.Label(root, text="Max Price").grid(row=3, column=0, sticky="w")
+max_price_entry = tk.Entry(root)
+max_price_entry.grid(row=3, column=1)
+
+# Condition
+tk.Label(root, text="Condition").grid(row=4, column=0, sticky="w")
+condition_var = tk.StringVar(value="Any")
+condition_menu = tk.OptionMenu(root, condition_var, "Any", "New", "Used")
+condition_menu.grid(row=4, column=1, sticky="ew")
+
+# Listing type
+tk.Label(root, text="Listing Type").grid(row=5, column=0, sticky="w")
+listing_type_var = tk.StringVar(value="Both")
+listing_type_menu = tk.OptionMenu(root, listing_type_var, "Auction", "BIN", "Both")
+listing_type_menu.grid(row=5, column=1, sticky="ew")
+
+# Time left
+tk.Label(root, text="Max Time Left").grid(row=6, column=0, sticky="w")
+time_left_var = tk.StringVar(value="Any")
+time_left_menu = tk.OptionMenu(root, time_left_var, "Any", "24h", "48h")
+time_left_menu.grid(row=6, column=1, sticky="ew")
+
+# Exclude keywords
+tk.Label(root, text="Exclude Keywords").grid(row=7, column=0, sticky="w")
+exclude_entry = tk.Entry(root)
+exclude_entry.grid(row=7, column=1)
+
+# Result count
+tk.Label(root, text="Results").grid(row=8, column=0, sticky="w")
+result_var = tk.IntVar(value=20)
+result_scale = tk.Scale(root, from_=10, to=100, orient=tk.HORIZONTAL, variable=result_var)
+result_scale.grid(row=8, column=1, sticky="ew")
+
+# Fetch button
+fetch_button = tk.Button(root, text="Fetch Listings", command=fetch_from_gui)
+fetch_button.grid(row=9, column=0, columnspan=2, pady=10)
+
+if __name__ == "__main__":
+    root.mainloop()


### PR DESCRIPTION
## Summary
- Add `gui.py` with a Tkinter interface for setting watch filters and exporting results.
- Extend `fetch_listings` to support optional model, price range, condition, listing type, time left, excluded keywords, and variable result count.

## Testing
- `python -m py_compile src/ebay_api.py src/gui.py`
- `python src/main.py` *(fails: EBAY_APP_ID environment variable is not set)*
- `python src/gui.py` *(fails: no display name and no $DISPLAY environment variable)*

------
https://chatgpt.com/codex/tasks/task_e_68c618b3d32083318951982e5ee7ed69