### PR TITLE
docs: add virtual environment setup instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,32 @@
-{\rtf1\ansi\ansicpg1252\cocoartf2822
-\cocoatextscaling0\cocoaplatform0{\fonttbl}
-{\colortbl;\red255\green255\blue255;}
-{\*\expandedcolortbl;;}
-\margl1440\margr1440\vieww11520\viewh8400\viewkind0
-}
+# Watch Deals
+
+## Setup & Usage
+
+### Prerequisites
+- Python 3 installed on your system (macOS or Linux).
+
+Using a virtual environment keeps this project's dependencies isolated, so these steps won't alter your system Python installation.
+
+### Steps
+
+```bash
+# Create a virtual environment named 'venv'
+python3 -m venv venv
+
+# Activate the environment
+source venv/bin/activate
+
+# Install project dependencies
+python3 -m pip install -r requirements.txt
+
+# Run the GUI application
+python src/gui.py
+```
+
+When you're finished, leave the virtual environment with:
+
+```bash
+deactivate
+```
+
+You can safely delete the `venv` folder at any time to remove the environment without affecting your Mac.


### PR DESCRIPTION
## Summary
- document macOS virtual environment setup
- show how to install requirements and run the GUI

## Testing
- `python -m py_compile $(find src -name '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68c61be360748331b3cd5827c505e175