### PR TITLE
Align GUI filters with eBay API parameters

### DIFF
--- a/src/ebay_api.py
+++ b/src/ebay_api.py
@@ -9,55 +9,18 @@ from config import EBAY_APP_ID
 FINDING_API_ENDPOINT = "https://svcs.ebay.com/services/search/FindingService/v1"
 
 
-def build_item_filters(
-    min_price: Optional[str], max_price: Optional[str], condition: Optional[str]
-) -> List[Dict[str, str]]:
-    """Construct eBay ``itemFilter`` objects.
-
-    Filters are appended in the order required by the API:
-    MinPrice -> MaxPrice -> Currency -> Condition.  Any ``None`` values are
-    ignored, but the relative order of the remaining filters is preserved.
-
-    Parameters
-    ----------
-    min_price, max_price : Optional[str]
-        Minimum and maximum prices supplied by the GUI.
-    condition : Optional[str]
-        Human-readable condition (e.g. ``"New"`` or ``"Used"``).
-
-    Returns
-    -------
-    List[Dict[str, str]]
-        A list of filter dictionaries ready to be inserted into the request
-        parameters.
-    """
-
-    item_filters: List[Dict[str, str]] = []
-
-    if min_price:
-        item_filters.append({"name": "MinPrice", "value": str(min_price)})
-    if max_price:
-        item_filters.append({"name": "MaxPrice", "value": str(max_price)})
-
-    # Currency must always be provided, regardless of price filters
-    item_filters.append({"name": "Currency", "value": "USD"})
-
-    condition_map = {"New": "1000", "Used": "3000"}
-    if condition in condition_map:
-        item_filters.append({"name": "Condition", "value": condition_map[condition]})
-
-    return item_filters
-
-
-def fetch_listings(params: Dict[str, Any]) -> Dict[str, Any]:
+def fetch_listings(
+    params: Dict[str, Any], item_filters: Optional[List[Dict[str, str]]] = None
+) -> Dict[str, Any]:
     """Fetch listings from eBay using the Finding API.
 
     Parameters
     ----------
     params : Dict[str, Any]
-        Query parameters to send with the request.  ``min_price``, ``max_price``
-        and ``condition`` values may be included and will be converted into the
-        appropriate ``itemFilter`` entries.
+        Query parameters to send with the request.
+    item_filters : Optional[List[Dict[str, str]]]
+        List of item filter dictionaries (``name``/``value`` pairs and optional
+        ``paramName``/``paramValue``) to be inserted into the request.
 
     Returns
     -------
@@ -65,13 +28,14 @@ def fetch_listings(params: Dict[str, Any]) -> Dict[str, Any]:
         Parsed JSON response from the API.
     """
 
-    min_price = params.pop("min_price", None)
-    max_price = params.pop("max_price", None)
-    condition = params.pop("condition", None)
-
-    for idx, fil in enumerate(build_item_filters(min_price, max_price, condition)):
-        params[f"itemFilter({idx}).name"] = fil["name"]
-        params[f"itemFilter({idx}).value"] = fil["value"]
+    if item_filters:
+        for idx, fil in enumerate(item_filters):
+            params[f"itemFilter({idx}).name"] = fil["name"]
+            params[f"itemFilter({idx}).value"] = fil["value"]
+            if "paramName" in fil:
+                params[f"itemFilter({idx}).paramName"] = fil["paramName"]
+            if "paramValue" in fil:
+                params[f"itemFilter({idx}).paramValue"] = fil["paramValue"]
 
     headers = {
         "X-EBAY-SOA-SECURITY-APPNAME": EBAY_APP_ID,

--- a/src/main.py
+++ b/src/main.py
@@ -10,21 +10,45 @@ def main() -> None:
     brand = "Seiko"
     max_price = 500
 
-    listings = fetch_listings(brand, max_price)
-    df = pd.DataFrame(listings)
-    if not df.empty:
-        df.rename(
-            columns={
-                "title": "Title",
-                "price": "Price",
-                "url": "URL",
-                "end_time": "End Time",
-            },
-            inplace=True,
-        )
-    else:
-        df = pd.DataFrame(columns=["Title", "Price", "URL", "End Time"])
+    params = {
+        "keywords": f"{brand} watch",
+        "paginationInput.entriesPerPage": 20,
+    }
+    item_filters = [
+        {
+            "name": "MaxPrice",
+            "value": str(max_price),
+            "paramName": "Currency",
+            "paramValue": "USD",
+        }
+    ]
 
+    data = fetch_listings(params, item_filters)
+    items = (
+        data.get("findItemsByKeywordsResponse", [{}])[0]
+        .get("searchResult", [{}])[0]
+        .get("item", [])
+    )
+    listings = []
+    for item in items:
+        title = item.get("title", [""])[0]
+        price = (
+            item.get("sellingStatus", [{}])[0]
+            .get("currentPrice", [{}])[0]
+            .get("__value__")
+        )
+        url = item.get("viewItemURL", [""])[0]
+        end_time = item.get("listingInfo", [{}])[0].get("endTime", [""])[0]
+        listings.append(
+            {
+                "Title": title,
+                "Price": float(price) if price is not None else None,
+                "URL": url,
+                "End Time": end_time,
+            }
+        )
+
+    df = pd.DataFrame(listings, columns=["Title", "Price", "URL", "End Time"])
     export_to_excel(df)
     print(f"✅ Exported {len(df)} listings to listings.xlsx")
 


### PR DESCRIPTION
## Summary
- Map GUI condition and listing type options to official eBay codes and pass them directly to the API
- Simplify API wrapper to accept pre-built item filter dictionaries
- Update CLI example for new API interface

## Testing
- `python -m py_compile src/gui.py src/ebay_api.py src/main.py`


------
https://chatgpt.com/codex/tasks/task_e_68c76167a4088331b93c293c44f622df