### PR TITLE
Fix ListingType placement in eBay API request

### DIFF
--- a/src/ebay_api.py
+++ b/src/ebay_api.py
@@ -10,7 +10,9 @@ FINDING_API_ENDPOINT = "https://svcs.ebay.com/services/search/FindingService/v1"
 
 
 def fetch_listings(
-    params: Dict[str, Any], item_filters: Optional[List[Dict[str, str]]] = None
+    params: Dict[str, Any],
+    item_filters: Optional[List[Dict[str, str]]] = None,
+    listing_type: Optional[str] = None,
 ) -> Dict[str, Any]:
     """Fetch listings from eBay using the Finding API.
 
@@ -21,6 +23,8 @@ def fetch_listings(
     item_filters : Optional[List[Dict[str, str]]]
         List of item filter dictionaries (``name``/``value`` pairs and optional
         ``paramName``/``paramValue``) to be inserted into the request.
+    listing_type : Optional[str]
+        eBay listing type to include as a top-level request parameter.
 
     Returns
     -------
@@ -29,13 +33,24 @@ def fetch_listings(
     """
 
     if item_filters:
-        for idx, fil in enumerate(item_filters):
+        processed_filters: List[Dict[str, str]] = []
+        for fil in item_filters:
+            # ListingType must be a top-level parameter, not an item filter
+            if fil.get("name") == "ListingType":
+                listing_type = fil.get("value")
+                continue
+            processed_filters.append(fil)
+
+        for idx, fil in enumerate(processed_filters):
             params[f"itemFilter({idx}).name"] = fil["name"]
             params[f"itemFilter({idx}).value"] = fil["value"]
             if "paramName" in fil:
                 params[f"itemFilter({idx}).paramName"] = fil["paramName"]
             if "paramValue" in fil:
                 params[f"itemFilter({idx}).paramValue"] = fil["paramValue"]
+
+    if listing_type:
+        params["listingType"] = listing_type
 
     headers = {
         "X-EBAY-SOA-SECURITY-APPNAME": EBAY_APP_ID,


### PR DESCRIPTION
## Summary
- allow `fetch_listings` to accept `listing_type` separately from `item_filters`
- strip `ListingType` from `item_filters` and send it as a top-level `listingType` parameter

## Testing
- `pytest`
- `python -m py_compile $(git ls-files '*.py')`
- `python - <<'PY'
import os, sys
os.environ['EBAY_APP_ID'] = 'test'
sys.path.append('src')
from ebay_api import fetch_listings
import ebay_api
class MockResponse:
    def __init__(self, url, headers, params):
        self.url = url
        self.headers = headers
        self.params = params
    def raise_for_status(self):
        pass
    def json(self):
        return {'url': self.url, 'headers': self.headers, 'params': self.params}

def mock_get(url, headers=None, params=None, timeout=None):
    return MockResponse(url, headers, params)

ebay_api.requests.get = mock_get
params = {'keywords': 'watch'}
item_filters = [
    {'name': 'Condition', 'value': '3000'},
    {'name': 'MinPrice', 'value': '10', 'paramName': 'Currency', 'paramValue': 'USD'},
    {'name': 'ListingType', 'value': 'Auction'},
]
result = fetch_listings(params, item_filters)
print(result['params'])
PY`

------
https://chatgpt.com/codex/tasks/task_e_68c76e5bbaf48331a258c87f86f926df