### PR TITLE
Fix ListingType placement in eBay API request

### DIFF
--- a/src/ebay_api.py
+++ b/src/ebay_api.py
@@ -24,7 +24,7 @@ def fetch_listings(
         List of item filter dictionaries (``name``/``value`` pairs and optional
         ``paramName``/``paramValue``) to be inserted into the request.
     listing_type : Optional[str]
-        eBay listing type to include as a top-level request parameter.
+        eBay listing type to include as an ``itemFilter`` entry.
 
     Returns
     -------
@@ -32,25 +32,22 @@ def fetch_listings(
         Parsed JSON response from the API.
     """
 
-    if item_filters:
-        processed_filters: List[Dict[str, str]] = []
-        for fil in item_filters:
-            # ListingType must be a top-level parameter, not an item filter
-            if fil.get("name") == "ListingType":
-                listing_type = fil.get("value")
-                continue
-            processed_filters.append(fil)
-
-        for idx, fil in enumerate(processed_filters):
-            params[f"itemFilter({idx}).name"] = fil["name"]
-            params[f"itemFilter({idx}).value"] = fil["value"]
-            if "paramName" in fil:
-                params[f"itemFilter({idx}).paramName"] = fil["paramName"]
-            if "paramValue" in fil:
-                params[f"itemFilter({idx}).paramValue"] = fil["paramValue"]
+    if item_filters is None:
+        item_filters = []
+    else:
+        # Copy to avoid mutating the caller's list when appending filters.
+        item_filters = list(item_filters)
 
     if listing_type:
-        params["listingType"] = listing_type
+        item_filters.append({"name": "ListingType", "value": listing_type})
+
+    for idx, fil in enumerate(item_filters):
+        params[f"itemFilter({idx}).name"] = fil["name"]
+        params[f"itemFilter({idx}).value"] = fil["value"]
+        if "paramName" in fil:
+            params[f"itemFilter({idx}).paramName"] = fil["paramName"]
+        if "paramValue" in fil:
+            params[f"itemFilter({idx}).paramValue"] = fil["paramValue"]
 
     headers = {
         "X-EBAY-SOA-SECURITY-APPNAME": EBAY_APP_ID,


### PR DESCRIPTION
## Summary
- Always send ListingType as an itemFilter entry instead of a top-level `listingType` parameter.
- Ensure listing type filters get appended and serialized with other filters.

## Testing
- `python -m py_compile src/ebay_api.py src/gui.py src/excel_exporter.py src/main.py src/config.py`
- `pytest -q`
- `python - <<'PY'
import os, sys
sys.path.append('src')
os.environ['EBAY_APP_ID'] = 'DUMMY'
from ebay_api import fetch_listings
import requests

def dummy_get(url, headers=None, params=None, timeout=None):
    print('REQUEST', params)
    class DummyResponse:
        def raise_for_status(self):
            pass
        def json(self):
            return {}
    return DummyResponse()

requests.get = dummy_get

print('Auction:')
fetch_listings({'keywords': 'watch'}, listing_type='Auction')
print('FixedPrice:')
fetch_listings({'keywords': 'watch'}, listing_type='FixedPrice')
PY`

------
https://chatgpt.com/codex/tasks/task_e_68c771885da08331a5831b35dd89372c