### PR TITLE
Build indexed eBay itemFilter groups

### DIFF
--- a/src/gui.py
+++ b/src/gui.py
@@ -142,16 +142,8 @@ def on_fetch_click():
     if max_time_left_value:
         filters.append({"name": "MaxTimeLeft", "value": max_time_left_value})
 
-    for idx, fil in enumerate(filters):
-        params[f"itemFilter({idx}).name"] = fil["name"]
-        params[f"itemFilter({idx}).value"] = fil["value"]
-        if fil.get("paramName"):
-            params[f"itemFilter({idx}).paramName"] = fil["paramName"]
-        if fil.get("paramValue"):
-            params[f"itemFilter({idx}).paramValue"] = fil["paramValue"]
-
     try:
-        data = fetch_listings(params)
+        data = fetch_listings(params, item_filters=filters)
     except Exception as exc:
         messagebox.showerror("Error", str(exc))
         return


### PR DESCRIPTION
## Summary
- normalize and validate filter entries, defaulting price filters to USD
- flatten all filters into indexed `itemFilter(n)` params before calling the eBay Finding API
- wire GUI to pass filter dictionaries directly to the API client

## Testing
- `python -m pytest`
- `python -m py_compile src/ebay_api.py src/gui.py`


------
https://chatgpt.com/codex/tasks/task_e_68c792fe53508331ad10d8fe1df12916