### PR TITLE
Add Browse API test script with OAuth authentication

### DIFF
--- a/src/test_raw_request.py
+++ b/src/test_raw_request.py
@@ -1,0 +1,144 @@
+"""Manual test script that queries the eBay Browse API.
+
+This script replaces the legacy Finding API usage with the modern Browse API
+and authenticates using the OAuth2 client credentials flow.  Provide your eBay
+application credentials via the ``EBAY_CLIENT_ID`` and ``EBAY_CLIENT_SECRET``
+environment variables before running the script::
+
+    export EBAY_CLIENT_ID="your-client-id"
+    export EBAY_CLIENT_SECRET="your-client-secret"
+    python src/test_raw_request.py watch
+
+The script prints a summary of the first 10 search results including the title,
+price, and item URL.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+from typing import Iterable, List
+
+import requests
+
+TOKEN_URL = "https://api.ebay.com/identity/v1/oauth2/token"
+BROWSE_SEARCH_URL = "https://api.ebay.com/buy/browse/v1/item_summary/search"
+# The default scope required for application access tokens when calling the
+# Browse API.
+APPLICATION_SCOPE = "https://api.ebay.com/oauth/api_scope"
+# Sensible defaults to exercise the Browse API in a development environment.
+DEFAULT_KEYWORD = "watch"
+DEFAULT_RESULT_LIMIT = 20
+
+
+class MissingConfigurationError(RuntimeError):
+    """Raised when required environment variables are missing."""
+
+
+def _get_env(name: str) -> str:
+    """Fetch an environment variable or raise an informative error."""
+
+    value = os.getenv(name)
+    if not value:
+        raise MissingConfigurationError(
+            f"Environment variable '{name}' must be set to run the Browse API test."
+        )
+    return value
+
+
+def fetch_access_token(client_id: str, client_secret: str) -> str:
+    """Retrieve an OAuth2 application access token from eBay."""
+
+    response = requests.post(
+        TOKEN_URL,
+        auth=(client_id, client_secret),
+        headers={"Content-Type": "application/x-www-form-urlencoded"},
+        data={"grant_type": "client_credentials", "scope": APPLICATION_SCOPE},
+        timeout=10,
+    )
+    response.raise_for_status()
+    token_payload = response.json()
+    access_token = token_payload.get("access_token")
+    if not access_token:
+        raise RuntimeError("OAuth token response did not include an access_token")
+    return access_token
+
+
+def search_browse_api(access_token: str, keyword: str, limit: int = DEFAULT_RESULT_LIMIT) -> List[dict]:
+    """Query the Browse API for items matching ``keyword``."""
+
+    response = requests.get(
+        BROWSE_SEARCH_URL,
+        params={"q": keyword, "limit": str(limit)},
+        headers={
+            "Authorization": f"Bearer {access_token}",
+            "Content-Type": "application/json",
+        },
+        timeout=10,
+    )
+    response.raise_for_status()
+    payload = response.json()
+    items = payload.get("itemSummaries")
+    if not isinstance(items, list):
+        return []
+    return items
+
+
+def _format_price(item: dict) -> str:
+    """Create a human-readable price string from an item summary."""
+
+    price_info = item.get("price") or {}
+    value = price_info.get("value")
+    currency = price_info.get("currency")
+    if value and currency:
+        return f"{value} {currency}"
+    if value:
+        return str(value)
+    return "Price unavailable"
+
+
+def _iter_display_lines(items: Iterable[dict]) -> Iterable[str]:
+    """Yield formatted lines for each item summary."""
+
+    for index, item in enumerate(items, start=1):
+        title = item.get("title") or "Untitled item"
+        price = _format_price(item)
+        url = item.get("itemWebUrl") or item.get("itemAffiliateWebUrl") or "No URL available"
+        yield f"{index:02d}. {title} | {price} | {url}"
+
+
+def main() -> None:
+    """Entry point for running the Browse API smoke test."""
+
+    keyword = sys.argv[1] if len(sys.argv) > 1 else DEFAULT_KEYWORD
+    client_id = _get_env("EBAY_CLIENT_ID")
+    client_secret = _get_env("EBAY_CLIENT_SECRET")
+
+    print(f"Fetching OAuth token for client '{client_id}'...")
+    access_token = fetch_access_token(client_id, client_secret)
+
+    print(f"Searching Browse API for keyword: {keyword!r}")
+    items = search_browse_api(access_token, keyword)
+    if not items:
+        print("No items returned by the Browse API.")
+        return
+
+    print("Results:")
+    for line in _iter_display_lines(items[:10]):
+        print(line)
+
+
+if __name__ == "__main__":
+    try:
+        main()
+    except MissingConfigurationError as exc:
+        sys.stderr.write(f"Configuration error: {exc}\n")
+        sys.exit(1)
+    except requests.HTTPError as exc:
+        # Surface HTTP errors directly to aid debugging of authentication or
+        # request issues.
+        sys.stderr.write(f"HTTP error: {exc.response.status_code} {exc.response.text}\n")
+        sys.exit(1)
+    except requests.RequestException as exc:
+        sys.stderr.write(f"Network error: {exc}\n")
+        sys.exit(1)


### PR DESCRIPTION
## Summary
- replace the legacy raw request script with a Browse API-based implementation
- add OAuth client-credential token retrieval and result formatting with titles, prices, and URLs

## Testing
- python -m compileall src/test_raw_request.py

------
https://chatgpt.com/codex/tasks/task_e_68d0888d9e4483318eda582b9b0dd22c