### PR TITLE
Implement token entry flow for GUI

### DIFF
--- a/src/ebay_api.py
+++ b/src/ebay_api.py
@@ -1,12 +1,17 @@
+from typing import Optional
+
 import requests
 from src import token_manager
 
 
-def fetch_listings(query: dict):
+def fetch_listings(query: dict, token: Optional[str] = None):
     url = "https://api.ebay.com/buy/browse/v1/item_summary/search"
 
+    if token is None:
+        token = token_manager.get_token()
+
     headers = {
-        "Authorization": f"Bearer {token_manager.get_token()}",
+        "Authorization": f"Bearer {token}",
         "Content-Type": "application/json",
     }
 


### PR DESCRIPTION
## Summary
- add a startup token entry dialog that captures an OAuth token before launching the watch listings fetcher GUI
- store the token for the session and ensure listings requests use the saved value when calling the eBay API

## Testing
- not run (GUI application)


------
https://chatgpt.com/codex/tasks/task_e_68d5ba24f6b88331ac8777f9676af7f8